### PR TITLE
Update to MbedTLS v3.6.2 and Zig 0.14.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: 0.14.0
 
       - name: Build
         run: zig build -Dtarget=${{ matrix.target }} -Doptimize=${{ matrix.optimize }}
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: 0.14.0
 
       - name: Test
         run: zig build test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v1
         with:
-          version: 0.14.0
+          version: master
 
       - name: Build
         run: zig build -Dtarget=${{ matrix.target }} -Doptimize=${{ matrix.optimize }}
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v1
         with:
-          version: 0.14.0
+          version: master
 
       - name: Test
         run: zig build test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v1
         with:
-          version: master
+          version: 0.14.0
 
       - name: Build
         run: zig build -Dtarget=${{ matrix.target }} -Doptimize=${{ matrix.optimize }}
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v1
         with:
-          version: master
+          version: 0.14.0
 
       - name: Test
         run: zig build test

--- a/build.zig
+++ b/build.zig
@@ -33,7 +33,7 @@ pub fn build(b: *Build) void {
         .optimize = optimize,
         .link_libc = true,
     });
-    selftest.defineCMacro("MBEDTLS_SELF_TEST", null);
+    selftest.root_module.addCMacro("MBEDTLS_SELF_TEST", "");
     selftest.addCSourceFile(.{
         .file = mbedtls_dep.path("programs/test/selftest.c"),
         .flags = &.{},

--- a/build.zig
+++ b/build.zig
@@ -7,11 +7,14 @@ pub fn build(b: *Build) void {
 
     const mbedtls_dep = b.dependency("mbedtls", .{});
 
-    const mbedtls = b.addStaticLibrary(.{
+    const mbedtls = b.addLibrary(.{
         .name = "mbedtls",
-        .target = target,
-        .optimize = optimize,
-        .link_libc = true,
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
     });
     mbedtls.root_module.addIncludePath(mbedtls_dep.path("include"));
     mbedtls.root_module.addCSourceFiles(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,10 +1,11 @@
 .{
-    .name = "mbedtls",
+    .name = .mbedtls,
+    .fingerprint = 0x841b00c247548313,
     .version = "3.6.2",
     .dependencies = .{
         .mbedtls = .{
             .url = "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/mbedtls-3.6.2.tar.gz",
-            .hash = "1220df23c1e89d301f43026518f90e75cbfd91d92f9e62e5243268eec1db1b425db1",
+            .hash = "N-V-__8AAPnFhALfI8HonTAfQwJlGPkOdcv9kdkvnmLlJDJo",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,10 +1,10 @@
 .{
     .name = "mbedtls",
-    .version = "3.6.1",
+    .version = "3.6.2",
     .dependencies = .{
         .mbedtls = .{
-            .url = "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/mbedtls-3.6.1.tar.gz",
-            .hash = "1220b612b5a244c7b5ad5482cf2bb838e5d565abee98190220f3c568e847cd44306b",
+            .url = "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/mbedtls-3.6.2.tar.gz",
+            .hash = "1220df23c1e89d301f43026518f90e75cbfd91d92f9e62e5243268eec1db1b425db1",
         },
     },
     .paths = .{


### PR DESCRIPTION
I'm in the process of updating the libgit2 package to 0.14.0 which now relies on this one. I bumped the upstream version as well since there was a security patch.

~Not sure if the workflow version changes are correct, should it target the latest pre-release on https://ziglang.org/download/ instead?~